### PR TITLE
Fix: Adjust calendar container width to fit viewport

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -17,8 +17,8 @@ html, body {
     padding: 1rem;
 }
 .calendar-container {
-    max-width: 6xl;
-    width: 100%;
+    max-width: 72rem;
+    width: 90vw;
     background-color: white;
     border-radius: 1rem;
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);


### PR DESCRIPTION
The calendar container was previously set to `width: 100%`, which caused it to overflow the viewport on some screen sizes. The `max-width` property was also using an invalid value (`6xl`) and was being ignored by browsers.

This change adjusts the styling of the `.calendar-container` to ensure it fits within the viewport.
- Replaced `width: 100%` with `width: 90vw` to make the calendar's width relative to the viewport.
- Corrected the invalid `max-width: 6xl` to a valid CSS value of `max-width: 72rem`.

This ensures the calendar is responsive and does not exceed the viewport's boundaries, improving the user experience on all devices.